### PR TITLE
Install dir conf

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -8,8 +8,10 @@ enable-email = true
 logging-on = true 
 # your working directory:
 master_rocket_chip_dir = /scratch/sagark/pb-runs-test
+# installation directory (networked) of riscv-tests and riscv-toolsa
+install_dir = /nscratch/bar-crawl
 # risc-v tools install:
-rvenv = /nscratch/bar-crawl/tools-installs/6830b9584e17a06167d5df51c42e08e85cc8334c
+rvenv_hash = 6830b9584e17a06167d5df51c42e08e85cc8334c
 
 [tests]
 # anything marked true below will be compiled/run

--- a/run-job.py
+++ b/run-job.py
@@ -86,13 +86,13 @@ def do_jackhammer():
     #create a directory in distribute for each design, test
     for x in designs:
         for y in userjobconfig.tests:
-            local('mkdir -p ' + fulljobdir + '/' + x + '/' + y)
+            local('mkdir -p -m 0775 ' + fulljobdir + '/' + x + '/' + y)
         # always make the emulator directory
-        local('mkdir -p ' + fulljobdir + '/' + x + '/emulator')
+        local('mkdir -p -m 0775 ' + fulljobdir + '/' + x + '/emulator')
 
     # directory to store patches if there are local changes
     patchdir = fulljobdir + '/patches'
-    local('mkdir -p ' + patchdir)
+    local('mkdir -p -m 0775 ' + patchdir)
     generate_recursive_patches(userjobconfig.master_rocket_chip_dir, patchdir)
 
 def build_riscv_tests():
@@ -101,7 +101,7 @@ def build_riscv_tests():
     if hashes['riscv-tests'] == hashes['riscv-tools']:
         print(bcolors.FAIL + "riscv-tests hash matches riscv-tools hash. Did you forget to init the\nriscv-tests submodule?" + bcolors.ENDC)
         exit(1)
-    with lcd('/nscratch/bar-crawl/tests-installs'), shell_env(**userjobconfig.shell_env_args), settings(warn_only=True):
+    with lcd(userjobconfig.install_dir + '/tests-installs'), shell_env(**userjobconfig.shell_env_args), settings(warn_only=True):
         local('git clone ' + userjobconfig.tests_location + ' ' + hashes['riscv-tests'])
         local('cd ' + hashes['riscv-tests'] + ' && git checkout ' + hashes['riscv-tests'])
         local('cd ' + hashes['riscv-tests'] + ' && git submodule update --init')

--- a/tasks.py
+++ b/tasks.py
@@ -161,14 +161,14 @@ def compile_and_copy(self, design_name, hashes, jobinfo, userjobconfig):
         email_user(userjobconfig, jobinfo, design_name)
     return rs
 
-sampleemulator = "./emulator-Top-{} +dramsim +max-cycles=100000000 +verbose +loadmem=/nscratch/bar-crawl/tests-installs/{}/{}/{}.hex none 3>&1 1>&2 2>&3 | spike-dasm --extension=hwacha > ../{}.out && [ $PIPESTATUS -eq 0 ]"
+sampleemulator = "./emulator-Top-{} +dramsim +max-cycles=100000000 +verbose +loadmem={}/tests-installs/{}/{}/{}.hex none 3>&1 1>&2 2>&3 | spike-dasm --extension=hwacha > ../{}.out && [ $PIPESTATUS -eq 0 ]"
 
 def emulator(design_name, test_to_run, jobinfo, userjobconfig):
     """ run a test """
     workdir = userjobconfig.distribute_rocket_chip_loc + '/' + jobinfo + '/' + design_name + '/emulator/emulator'
     test_type, test_to_run = split_test_name(test_to_run)
     with lcd(workdir), shell_env(**userjobconfig.shell_env_args), settings(warn_only=True):
-        res = local(sampleemulator.format(design_name, userjobconfig.hashes['riscv-tests'], test_type, test_to_run, test_to_run), shell='/bin/bash')
+        res = local(sampleemulator.format(design_name, userjobconfig.install_dir, userjobconfig.hashes['riscv-tests'], test_type, test_to_run, test_to_run), shell='/bin/bash')
         if res.failed:
             return "FAIL"
         q = local("tail -n 1 ../{}.out".format(test_to_run), capture=True)
@@ -184,7 +184,7 @@ def emulatortest(self, design_name, testname, jobinfo, userjobconfig):
     except SoftTimeLimitExceeded:
         return limit_exceeded()
 
-samplevcs = "cd . && ./simv-Top-{} -q +ntb_random_seed_automatic +dramsim +verbose +max-cycles=100000000 +loadmem=/nscratch/bar-crawl/tests-installs/{}/{}/{}.hex 3>&1 1>&2 2>&3 | spike-dasm --extension=hwacha > ../{}.out && [ $PIPESTATUS -eq 0 ]"
+samplevcs = "cd . && ./simv-Top-{} -q +ntb_random_seed_automatic +dramsim +verbose +max-cycles=100000000 +loadmem={}/tests-installs/{}/{}/{}.hex 3>&1 1>&2 2>&3 | spike-dasm --extension=hwacha > ../{}.out && [ $PIPESTATUS -eq 0 ]"
 
 def vsim(design_name, test_to_run, jobinfo, userjobconfig):
     """ run a test """
@@ -192,7 +192,7 @@ def vsim(design_name, test_to_run, jobinfo, userjobconfig):
     test_type, test_to_run = split_test_name(test_to_run)
 
     with lcd(workdir), shell_env(**userjobconfig.shell_env_args), settings(warn_only=True):
-        res = local(samplevcs.format(design_name, userjobconfig.hashes['riscv-tests'], test_type, test_to_run, test_to_run), shell='/bin/bash')
+        res = local(samplevcs.format(design_name, userjobconfig.install_dir, userjobconfig.hashes['riscv-tests'], test_type, test_to_run, test_to_run), shell='/bin/bash')
         if res.failed:
             return "FAIL"
         q = local("tail -n 1 ../{}.out".format(test_to_run), capture=True)
@@ -208,14 +208,14 @@ def vsimtest(self, design_name, testname, jobinfo, userjobconfig):
     except SoftTimeLimitExceeded:
         return limit_exceeded()
 
-samplevcs_sim_rtl = 'cd . && ./simv-Top-{} -q +ntb_random_seed_automatic +dramsim +verbose +max-cycles=100000000 +loadmem=/nscratch/bar-crawl/tests-installs/{}/{}/{}.hex 3>&1 1>&2 2>&3 | spike-dasm --extension=hwacha > ../{}.out && [ $PIPESTATUS -eq 0 ]'
+samplevcs_sim_rtl = 'cd . && ./simv-Top-{} -q +ntb_random_seed_automatic +dramsim +verbose +max-cycles=100000000 +loadmem={}/tests-installs/{}/{}/{}.hex 3>&1 1>&2 2>&3 | spike-dasm --extension=hwacha > ../{}.out && [ $PIPESTATUS -eq 0 ]'
 
 def vcs_sim_rtl(design_name, test_to_run, jobinfo, userjobconfig):
     """ run a test """
     workdir = userjobconfig.distribute_rocket_chip_loc + '/' + jobinfo + '/' + design_name + '/vcs-sim-rtl/vcs-sim-rtl'
     test_type, test_to_run = split_test_name(test_to_run)
     with lcd(workdir), shell_env(**userjobconfig.shell_env_args), settings(warn_only=True):
-        res = local(samplevcs_sim_rtl.format(design_name, userjobconfig.hashes['riscv-tests'], test_type, test_to_run, test_to_run), shell='/bin/bash')
+        res = local(samplevcs_sim_rtl.format(design_name, userjobconfig.install_dir, userjobconfig.hashes['riscv-tests'], test_type, test_to_run, test_to_run), shell='/bin/bash')
         if res.failed:
             return "FAIL"
         q = local("tail -n 1 ../{}.out".format(test_to_run), capture=True)
@@ -232,14 +232,14 @@ def vcs_sim_rtl_test(self, design_name, testname, jobinfo, userjobconfig):
         return limit_exceeded()
 
 
-samplevcs_sim_gl_syn = "cd . && ./simv-{} -ucli -do +run.tcl +dramsim +verbose +max-cycles=100000000 +loadmem=/nscratch/bar-crawl/tests-installs/{}/{}/{}.hex 3>&1 1>&2 2>&3 | spike-dasm --extension=hwacha > ../{}.out && [ $PIPESTATUS -eq 0 ]"
+samplevcs_sim_gl_syn = "cd . && ./simv-{} -ucli -do +run.tcl +dramsim +verbose +max-cycles=100000000 +loadmem={}/tests-installs/{}/{}/{}.hex 3>&1 1>&2 2>&3 | spike-dasm --extension=hwacha > ../{}.out && [ $PIPESTATUS -eq 0 ]"
 
 def vcs_sim_gl_syn(design_name, test_to_run, jobinfo, userjobconfig):
     """ run a test """
     workdir = userjobconfig.distribute_rocket_chip_loc + '/' + jobinfo + '/' + design_name + '/vcs-sim-gl-syn/vcs-sim-gl-syn'
     test_type, test_to_run = split_test_name(test_to_run)
     with lcd(workdir), shell_env(**userjobconfig.shell_env_args), prefix('source ' + vlsi_bashrc), settings(warn_only=True):
-        res = local(samplevcs_sim_gl_syn.format(design_name, userjobconfig.hashes['riscv-tests'], test_type, test_to_run, test_to_run), shell='/bin/bash')
+        res = local(samplevcs_sim_gl_syn.format(design_name,userjobconfig.install_dir, userjobconfig.hashes['riscv-tests'], test_type, test_to_run, test_to_run), shell='/bin/bash')
         if res.failed:
             return "FAIL"
         q = local("tail -n 1 ../{}.out".format(test_to_run), capture=True)

--- a/userconfig.py
+++ b/userconfig.py
@@ -39,13 +39,12 @@ class UserJobConfig:
         #
         # TODO: can auto-detect this based on what it's supposed to be from 
         # looking at master_rocket_chip_dir
-        self.rvenv = config.get('job', 'rvenv')
-
+        self.rvenv_installed_hash = config.get('job', 'rvenv_hash')
+        self.install_dir = config.get('job', 'install_dir')
         """ DO NOT MODIFY """
-        self.env_RISCV = self.rvenv
-        self.env_PATH = self.rvenv+"/bin:$PATH"
-        self.env_LD_LIBRARY = self.rvenv+"/lib"
-        self.rvenv_installed_hash = self.rvenv.split("/")[-1]
+        self.env_RISCV = self.install_dir+'/tools-installs/'+self.rvenv_installed_hash
+        self.env_PATH = self.env_RISCV+"/bin:$PATH"
+        self.env_LD_LIBRARY = self.env_RISCV+"/lib"
         """ END DO NOT MODIFY """
 
         self.MODEL = config.get('rocket-chip-setup', 'MODEL')


### PR DESCRIPTION
This PR does two things: 

1) Takes the installation directory in which riscv-tools, riscv-tests will reside. Rvenv thus becomes <install_dir>/riscv-tools/<sha ID>. Simulation task commands have also been updated. 

2) In run-job.py, generation of the result directory now adds g+rwx permissions, which i figured was prereq for anyone not Sagar running the tool. 
